### PR TITLE
Change base image to eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-alpine
 
 ENV JMB_VERSION 0.4.1
 


### PR DESCRIPTION
It appears that openjdk has been deprecated according to the [docker hub page](https://hub.docker.com/_/openjdk). The [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin) image is a popular and well-maintained jdk image and has an alpine image to help reduce the image's footprint without sacrificing functionality.

The new Dockerfile has been tested and works well with my existing jmusicbot configuration.